### PR TITLE
balanced AIG construction to avoid segfault due to deep recursion

### DIFF
--- a/src/arjun.h
+++ b/src/arjun.h
@@ -154,7 +154,6 @@ public:
         ret->type = AIGT::t_and;
         ret->l = a;
         ret->r = a;
-
         ret->neg = true;
         return ret;
     }
@@ -169,13 +168,13 @@ public:
         return ret;
     }
 
-    static aig_ptr new_or(const aig_ptr& l, const aig_ptr& r) {
+    static aig_ptr new_or(const aig_ptr& l, const aig_ptr& r, bool neg = false) {
         assert(l != nullptr && r != nullptr);
         auto ret = std::make_shared<AIG>();
         ret->type = AIGT::t_and;
-        ret->neg = true;
         ret->l = new_not(l);
         ret->r = new_not(r);
+        ret->neg = true ^ neg;
         return ret;
     }
 

--- a/src/interpolant.cpp
+++ b/src/interpolant.cpp
@@ -48,20 +48,20 @@ void MyTracer::add_derived_clause(uint64_t id, bool /*red*/, const std::vector<i
 
   const uint64_t id1 = rantec[0];
   auto aig = fs_clid[id1];
-  release_assert(aig != nullptr);
-  set<Lit> resolvent(cls[id1].begin(),cls[id1].end());
-  std::vector<aig_ptr> same_op_terms;
-  bool same_op_is_and = false;
-  bool same_op_started = false;
+  set<Lit> resolvent(cls[id1].begin(), cls[id1].end());
 
-  auto flush_terms = [&]() {
-      if (!same_op_started) return;
-      aig = combine_balanced(std::move(same_op_terms), same_op_is_and);
-      same_op_terms.clear();
-      same_op_started = false;
+  // Batch consecutive same-op steps for balanced tree construction,
+  // avoiding O(n)-depth AIGs that cause stack overflow on large proofs.
+  std::vector<aig_ptr> batch;
+  bool batch_is_and = false;
+  auto flush_batch = [&]() {
+      if (batch.empty()) return;
+      if (batch_is_and) aig = combine_balanced<AIG::new_and>(batch);
+      else              aig = combine_balanced<AIG::new_or>(batch);
+      batch.clear();
   };
 
-  for(uint32_t i = 1; i < rantec.size(); i++) {
+  for (uint32_t i = 1; i < rantec.size(); i++) {
       if (conf.verb >= 4) {
           cout << "resolvent: "; for(const auto& l: resolvent) cout << l << " "; cout << endl;
       }
@@ -81,25 +81,22 @@ void MyTracer::add_derived_clause(uint64_t id, bool /*red*/, const std::vector<i
           }
       }
       assert(res_lit != lit_Undef);
-      bool input_or_copy = input.count(res_lit.var()) || res_lit.var() >= (uint32_t)orig_num_vars;
-      auto rhs = fs_clid[id2];
-      release_assert(rhs != nullptr);
-      if (!same_op_started) {
-          same_op_started = true;
-          same_op_is_and = input_or_copy;
-          same_op_terms.push_back(aig);
-          same_op_terms.push_back(rhs);
-      } else if (same_op_is_and == input_or_copy) {
-          same_op_terms.push_back(rhs);
+      const bool input_or_copy = input.count(res_lit.var()) || res_lit.var() >= (uint32_t)orig_num_vars;
+
+      if (batch.empty()) {
+          batch_is_and = input_or_copy;
+          batch.push_back(aig);
+          batch.push_back(fs_clid[id2]);
+      } else if (batch_is_and == input_or_copy) {
+          batch.push_back(fs_clid[id2]);
       } else {
-          flush_terms();
-          same_op_started = true;
-          same_op_is_and = input_or_copy;
-          same_op_terms.push_back(aig);
-          same_op_terms.push_back(rhs);
+          flush_batch();
+          batch_is_and = input_or_copy;
+          batch.push_back(aig);
+          batch.push_back(fs_clid[id2]);
       }
   }
-  flush_terms();
+  flush_batch();
   fs_clid[id] = aig;
   verb_print(5, "intermediate formula: " << fs_clid[id]);
   if (clause.empty()) {

--- a/src/interpolant.h
+++ b/src/interpolant.h
@@ -34,7 +34,6 @@ extern "C" {
 #include "formula.h"
 #include <vector>
 #include <map>
-#include <utility>
 #include <cstdint>
 #include <cadical.hpp>
 #include <tracer.hpp>
@@ -64,19 +63,21 @@ struct MyTracer : public CaDiCaL::Tracer {
     // AIG cache
     map<Lit, aig_ptr>& lit_to_aig;
 
-    static aig_ptr combine_balanced(std::vector<aig_ptr> terms, bool use_and) {
-      release_assert(!terms.empty());
-      while (terms.size() > 1) {
-          std::vector<aig_ptr> next;
-          next.reserve((terms.size()+1)/2);
-          for(uint32_t i = 0; i < terms.size(); i += 2) {
-              if (i+1 >= terms.size()) next.push_back(terms[i]);
-              else if (use_and) next.push_back(AIG::new_and(terms[i], terms[i+1]));
-              else next.push_back(AIG::new_or(terms[i], terms[i+1]));
-          }
-          terms = std::move(next);
-      }
-      return terms[0];
+    // Balanced binary tree reduction using Op (AIG::new_and or AIG::new_or).
+    // Avoids deep recursion/stack overflow compared to linear left-to-right folding.
+    template<aig_ptr (*Op)(const aig_ptr&, const aig_ptr&, bool neg)>
+    static aig_ptr combine_balanced(vector<aig_ptr> terms) {
+        release_assert(!terms.empty());
+        vector<aig_ptr> next;
+        while (terms.size() > 1) {
+            next.clear();
+            for (size_t i = 0; i < terms.size(); i += 2) {
+                if (i + 1 >= terms.size()) next.push_back(terms[i]);
+                else next.push_back(Op(terms[i], terms[i + 1], false));
+            }
+            terms = next;
+        }
+        return terms[0];
     }
 
     aig_ptr get_aig(const Lit l) {
@@ -90,11 +91,10 @@ struct MyTracer : public CaDiCaL::Tracer {
       vector<Lit> cl = unsorted_cl;
       std::sort(cl.begin(), cl.end());
       if (cl.empty()) return aig_mng.new_const(false);
-
-      std::vector<aig_ptr> leaves;
+      vector<aig_ptr> leaves;
       leaves.reserve(cl.size());
-      for(const auto& l: cl) leaves.push_back(get_aig(l));
-      return combine_balanced(std::move(leaves), false);
+      for (const auto& l: cl) leaves.push_back(get_aig(l));
+      return combine_balanced<AIG::new_or>(leaves);
     };
 
     void add_derived_clause (uint64_t id, bool red, const std::vector<int> & clause,
@@ -139,3 +139,4 @@ private:
     vector<uint32_t> var_to_indic; //maps an ORIG VAR to an INDICATOR VAR
     vector<aig_ptr> defs; //definition of variables in terms of AIG. ORIGINAL number space
 };
+


### PR DESCRIPTION
I could get segfault on mac for min256 which happened due to AIG construction for defined variable. 


This should fix such issues. Essentially, instead of recursive construction; I used standard balanced construction. 